### PR TITLE
feat: Ordenar por año y mes en orden descendente

### DIFF
--- a/app/scripts/controllers/seguimientoycontrol/tecnico/carga_documentos_contratista.js
+++ b/app/scripts/controllers/seguimientoycontrol/tecnico/carga_documentos_contratista.js
@@ -424,6 +424,8 @@ angular.module('contractualClienteApp')
       //self.obtener_informacion_coordinador(self.contrato.IdDependencia);
       cumplidosCrudRequest.get('pago_mensual', $.param({
         query: "NumeroContrato:" + self.contrato.NumeroContratoSuscrito + ",VigenciaContrato:" + self.contrato.Vigencia + ",DocumentoPersonaId:" + self.Documento,
+        sortby: "Ano,Mes",
+        order: "desc,desc",
         limit: 0
       })).then(function (response) {
         contratoRequest.get('contrato', self.contrato.NumeroContratoSuscrito + '/' + self.contrato.Vigencia)


### PR DESCRIPTION
(Probar primero en local!)
este PR es para ordenar los cumplidos dejando el mas reciente de primeras

Antes:
![image](https://user-images.githubusercontent.com/6588872/168709015-9f4e4faa-093c-4f35-9e07-a783d1f27d2e.png)

Después:
![image](https://user-images.githubusercontent.com/6588872/168709195-0c22f695-bde2-49bc-94cf-933b93be7414.png)
(Nota: Captura de imprimir en consola con `console.table()` los datos retornados en el `Data` del Body de la respuesta