### PR TITLE
hotfix: se reajustan validaciones para doble cumplido cuando hay susp…

### DIFF
--- a/app/scripts/controllers/seguimientoycontrol/tecnico/carga_documentos_contratista.js
+++ b/app/scripts/controllers/seguimientoycontrol/tecnico/carga_documentos_contratista.js
@@ -443,9 +443,9 @@ angular.module('contractualClienteApp')
                 }
                 if (ultimaSuspension != null) {
                   var fechaInicio = ultimaSuspension.FechaInicio.split("-");
-                  var fechaFin = ultimaSuspension.FechaFin.split("-");
-                  if (fechaInicio[1] == self.mes && fechaInicio[0] == self.anio && fechaFin[1] == self.mes && fechaFin[0] == self.anio) {
+                  var fechaFin = ultimaSuspension.FechaFinSus.split("-");
 
+                  if (fechaInicio[1] == self.mes && fechaInicio[0] == self.anio && fechaFin[1] == self.mes && fechaFin[0] == self.anio) {
                     cumplidosCrudRequest.post("pago_mensual", pago_mensual_auditoria)
                       .then(function (responsePagoPost) {
                         swal(
@@ -951,3 +951,4 @@ angular.module('contractualClienteApp')
         });
     };
   });
+

--- a/app/scripts/controllers/seguimientoycontrol/tecnico/informe_gestion_y_certificado_cumplimiento.js
+++ b/app/scripts/controllers/seguimientoycontrol/tecnico/informe_gestion_y_certificado_cumplimiento.js
@@ -351,8 +351,8 @@ angular.module('contractualClienteApp')
                 sortby: "Id",
                 order: "asc",
                 limit: 2
-              })).then(function (response_pago_mensual) {
-                if (response_pago_mensual.data.Data.length > 1) {
+              })).then(function (response_pago_mensual) { 
+                if (response.data.Data.length > 1) {
                   try {
                     var preliquidaciones = response.data.Data;
                     var pago_mensual = response_pago_mensual.data.Data;
@@ -1138,3 +1138,4 @@ angular.module('contractualClienteApp').filter('excludeUsed', function () {
 
   return filter;
 });
+


### PR DESCRIPTION
De acuerdo a lo solicitado en la tarea iris https://iris.portaloas.udistrital.edu.co/scp/tasks.php?id=25767 se hace el ajuste correspondiente solucionando parcialmente el problema de no poder cargar dos cumplidos en el mismo mes cuando hay una suspensión de contrato 